### PR TITLE
docs: adiciona templates para PRs, bug reports e feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug
+about: Cria um relatório de bug
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+## Descreva o bug
+
+Uma descrição precisa e concisa do problema
+
+## Como reproduzir
+
+Descreva os passos necessários para reproduzir o problema
+
+1. Crie um '...'
+2. Edite o '...'
+3. Veja que '...' está como 'X', mas deveria ser 'Y'
+
+## Comportamento esperado
+Descreva como deveria ser o comportamento esperado da funcionalidade
+
+## Screenshots (optional)
+Se for ajudar no entendimento do bug, coloque as screenshots aqui.
+
+## Contexto adicional
+Se necessário, adicione qualquer informação aqui que ajude a entender o problema

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Solicitação de funcionalidade
+about: Dê uma ideia para o projeto
+title: ''
+labels: 'feature request'
+assignees: ''
+
+---
+
+## Descreva o problema que você quer resolver com essa feature
+
+Descreva de forma concisa do porquê essa funcionalidade é importante. Ex: "Eu sempre me frustro quando vou fazer 'X', poder fazer 'Y' deixaria a experiência muito melhor."
+
+## Descreva como você vê uma solução
+
+Descreva de forma conscisa como solucionar seu problema. Ex: seria bom se quando estiver na tela 'X', eu pudesse clicar em um botão 'P' que faz 'Y'.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Mudanças propostas
+
+Descreva aqui o que seu PR muda e o porquê ele deve ser aprovado.
+
+## Tipo de mudança
+
+- [ ] Correção de bug
+- [ ] Nova feature
+- [ ] Atualização de documentação
+
+## Checklist
+
+- [ ] Testei minhas mudanças
+- [ ] Escrevi pelo menos 1 teste automatizado


### PR DESCRIPTION
## Mudanças propostas

Adiciona templates para PRs (esse template) e para issues de `bug report` e `feature requests`. Me fundamentei nos templates que uso em alguns projetos e em templates do `github-issue-templates`

## Tipo de mudança

- [ ] Correção de bug
- [ ] Nova feature
- [x] Atualização de documentação

## Checklist

- [x] Testei minhas mudanças
- [ ] Escrevi pelo menos 1 teste automatizado