### PR TITLE
i64 - Botão favoritar para todos e conserto bug de unfavorite.

### DIFF
--- a/client/src/2pages/article/article-page.ui.tsx
+++ b/client/src/2pages/article/article-page.ui.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { withErrorBoundary } from 'react-error-boundary'
-import { IoAdd, IoHeart, IoPencil } from 'react-icons/io5'
+import { IoAdd, IoPencil } from 'react-icons/io5'
 import { Link, useLoaderData, useNavigate } from 'react-router-dom'
 import { compose, withSuspense } from '~6shared/lib/react'
 import { pathKeys } from '~6shared/lib/react-router'
@@ -146,7 +146,8 @@ function ArticleActions(props: { article: articleTypes.Article }) {
       {!canUpdateArticle && <ToggleFollowProfile profile={author} />}
       &nbsp;
       {canDeleteArticle && <DeleteArticleButton slug={article.slug} />}
-      {!canDeleteArticle && <ToggleFavoriteArticle article={article} />}
+      &nbsp;
+      <ToggleFavoriteArticle article={article} />
     </>
   )
 }
@@ -180,31 +181,30 @@ function ToggleFollowProfile(props: { profile: profileTypes.Profile }) {
 }
 
 function ToggleFavoriteArticle(props: { article: articleTypes.Article }) {
+  console.log('ToggleFavoriteArticle', props);
   const { article } = props
   const { favorited } = article
 
-  const canLikeArticle = PermissionService.useCanPerformAction(
-    'like',
-    'article',
-  )
-  const canDislikeArticle = PermissionService.useCanPerformAction(
-    'dislike',
-    'article',
-  )
-  const cannotLikeOrDislike = !canLikeArticle || !canDislikeArticle
+  // const canLikeArticle = PermissionService.useCanPerformAction(
+  //   'like',
+  //   'article',
+  // )
+  // const canDislikeArticle = PermissionService.useCanPerformAction(
+  //   'dislike',
+  //   'article',
+  // )
+  // const cannotLikeOrDislike = !canLikeArticle || !canDislikeArticle
 
-  const canLike = canLikeArticle && !favorited
-  const canDislike = canDislikeArticle && favorited
+  // const canLike = canLikeArticle && !favorited
+  // const canDislike = canDislikeArticle && favorited
+
+  const canLike = !favorited
+  const canDislike = favorited
 
   return (
     <>
       {canLike && <FavoriteArticleExtendedButton article={article} />}
       {canDislike && <UnfavoriteArticleExtendedButton article={article} />}
-      {cannotLikeOrDislike && (
-        <NavigateToLoginButtonFavorite
-          favoritesCount={article.favoritesCount}
-        />
-      )}
     </>
   )
 }
@@ -243,22 +243,22 @@ function NavigateToLoginButtonFollow(props: { username: string }) {
   )
 }
 
-function NavigateToLoginButtonFavorite(props: { favoritesCount: number }) {
-  const { favoritesCount } = props
+// function NavigateToLoginButtonFavorite(props: { favoritesCount: number }) {
+//   const { favoritesCount } = props
 
-  const navigate = useNavigate()
+//   const navigate = useNavigate()
 
-  const onClick = () => navigate(pathKeys.login())
+//   const onClick = () => navigate(pathKeys.login())
 
-  return (
-    <Button
-      color="primary"
-      variant="outline"
-      onClick={onClick}
-    >
-      <IoHeart size={16} />
-      &nbsp;Favorite Article&nbsp;
-      <span className="counter">({favoritesCount})</span>
-    </Button>
-  )
-}
+//   return (
+//     <Button
+//       color="primary"
+//       variant="outline"
+//       onClick={onClick}
+//     >
+//       <IoHeart size={16} />
+//       &nbsp;Favorite Article&nbsp;
+//       <span className="counter">({favoritesCount})</span>
+//     </Button>
+//   )
+// }

--- a/client/src/6shared/api/favorite/favorite.service.ts
+++ b/client/src/6shared/api/favorite/favorite.service.ts
@@ -11,7 +11,7 @@ export class FavoriteService {
 
   static unfavoriteArticleMutation(slug: string) {
     return realworld
-      .post(`/articles/${slug}/favorite`)
+      .delete(`/articles/${slug}/favorite`)
       .then(AxiosContracts.responseContract(FavoriteArticleDtoSchema))
   }
 }


### PR DESCRIPTION
## Mudanças propostas

Em atendimento à issue 64, o botão favoritar aparece para todos usuários e o bug na hora de apertar unfavorite foi consertado.

## Tipo de mudança

- [X] Correção de bug
- [ ] Nova feature
- [ ] Refactor / Otimização
- [ ] Atualização de documentação

## Checklist

- [X] Testei minhas mudanças
- [X] As mudanças não quebraram os testes existentes
- [X] As mudanças não afetam o fluxo de instalação descrito no README. Caso sim, atualizei o README.
- [ ] Escrevi pelo menos 1 teste automatizado
- [ ] Foi adicionado uma nova dependência ao projeto

## Issues

Issue resolvida por esse PR: 64

Issues relacionada a esse PR: -

## Instruções de testes

No feed e na página de artigo devem aparecer botões para favoritar e desfavoritar o artigo. Ademais, o botão deve desfavoritar o artigo quando clicado.