### PR TITLE
Feat/otel

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,20 @@
+FROM sail-8.3/app
+
+# Instale as dependências necessárias
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    gcc \
+    make \
+    unzip
+
+# Clone e instale a extensão OpenTelemetry
+RUN pecl install opentelemetry
+
+# Habilite a extensão
+RUN mkdir -p /etc/php/8.3/cli/conf.d && echo "extension=opentelemetry.so" > /etc/php/8.3/cli/conf.d/opentelemetry.ini
+
+
+# Limpe os arquivos temporários
+RUN rm -rf /tmp/opentelemetry \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
     laravel.test:
         build:
-            context: ./vendor/laravel/sail/runtimes/8.3
+            context: ./
             dockerfile: Dockerfile
             args:
                 NODE_VERSION: '20'
@@ -73,6 +73,20 @@ services:
             - '${FORWARD_MAILPIT_DASHBOARD_PORT:-8025}:8025'
         networks:
             - sail
+    collector:
+        image: otel/opentelemetry-collector:latest
+        command: ["--config=/etc/otel-collector-config.yaml"]
+        volumes:
+        - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+        ports:
+        - "4317:4317"
+        - "4318:4318"
+
+    jaeger:
+        image: jaegertracing/all-in-one:latest
+        ports:
+        - "16686:16686"
+        - "14250:14250"
 networks:
     sail:
         driver: bridge

--- a/server/otel-collector-config.yaml
+++ b/server/otel-collector-config.yaml
@@ -1,0 +1,25 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+
+exporters:
+  logging:
+    loglevel: debug
+  jaeger:
+    endpoint: jaeger:14250
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, jaeger]


### PR DESCRIPTION
## Mudanças propostas

Adiciona a auto-instrumentação do OpenTelemetry ao backend do projeto.

## Tipo de mudança

- [X] Nova feature

## Checklist

- [X] Testei minhas mudanças
- [X] As mudanças não quebraram os testes existentes
- [X] As mudanças não afetam o fluxo de instalação descrito no README. Caso sim, atualizei o README.
- [ ] Escrevi pelo menos 1 teste automatizado
- [X] Foi adicionado uma nova dependência ao projeto

## Issues

Issue resolvida por esse PR: #29

## Acessando a funcionalidade:

Com o backend rodando, os dados coletados pelo Open Telemetry poderão ser visualizados através da interface do Jaeger, acessando: http://localhost:16686

![image](https://github.com/user-attachments/assets/dd6c2b1d-fbfe-4b5d-ba7e-7803f49448f6)
