### PR TITLE
Corrige atualização das tags do artigo ao editar

### DIFF
--- a/client/src/4features/article/update-article/update-article.ui.tsx
+++ b/client/src/4features/article/update-article/update-article.ui.tsx
@@ -74,12 +74,13 @@ export const UpdateArticleForm = enhance((props: UpdateArticleFormProps) => {
   const canSubmit = [isDirty, isValid, !isPending].every(Boolean)
 
   const onSubmit = (updateArticle: UpdateArticle) => {
-    mutate({
-      ...currentArticle,
-      ...updateArticle,
-      tagList: updateArticle.tagList?.split(', ') || [],
-    })
-  }
+  const tags = updateArticle.tagList?.split(', ').map(tag => tag.trim()).filter(tag => tag) || []
+  mutate({
+    ...currentArticle,
+    ...updateArticle,
+    tagList: tags.length ? tags : [],
+  })
+}
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>

--- a/server/app/Http/Controllers/Api/Articles/ArticleController.php
+++ b/server/app/Http/Controllers/Api/Articles/ArticleController.php
@@ -123,14 +123,12 @@ final class ArticleController extends Controller
      */
     public function update(UpdateArticleRequest $request, string $slug): ArticleResource
     {
-        $user = $request->user();
         $article = Article::whereSlug($slug)
             ->firstOrFail();
 
         $this->authorize('update', $article);
 
         $attributes = $request->validated();
-        $attributes['author_id'] = $user->getKey();
 
         $tags = Arr::pull($attributes, 'tagList');
         $article->update($request->validated());

--- a/server/app/Http/Controllers/Api/Articles/ArticleController.php
+++ b/server/app/Http/Controllers/Api/Articles/ArticleController.php
@@ -91,7 +91,7 @@ final class ArticleController extends Controller
         $article = Article::create($attributes);
 
         if (is_array($tags)) {
-            $article->attachTags($tags);
+            $article->syncTags($tags);
         }
 
         return (new ArticleResource($article))
@@ -134,7 +134,7 @@ final class ArticleController extends Controller
         $article->update($request->validated());
 
         if (is_array($tags)) {
-            $article->attachTags($tags);
+            $article->syncTags($tags);
         }
 
         return new ArticleResource($article);

--- a/server/app/Http/Controllers/Api/Articles/ArticleController.php
+++ b/server/app/Http/Controllers/Api/Articles/ArticleController.php
@@ -134,7 +134,10 @@ final class ArticleController extends Controller
         $article->update($request->validated());
 
         if (is_array($tags)) {
-            $article->syncTags($tags);
+            if ($article->tagList !== $tags) {
+                $article->syncTags($tags);
+            }
+
         }
 
         return new ArticleResource($article);

--- a/server/app/Http/Controllers/Api/Articles/ArticleController.php
+++ b/server/app/Http/Controllers/Api/Articles/ArticleController.php
@@ -136,7 +136,11 @@ final class ArticleController extends Controller
         $article->update($request->validated());
 
         if (is_array($tags)) {
-            $article->attachTags($tags);
+            if (1 === count($tags) && empty($tags[0])) {
+                $article->attachTags([]);
+            } else {
+                $article->attachTags($tags);
+            }
         }
 
         return new ArticleResource($article);

--- a/server/app/Http/Controllers/Api/Articles/ArticleController.php
+++ b/server/app/Http/Controllers/Api/Articles/ArticleController.php
@@ -125,6 +125,7 @@ final class ArticleController extends Controller
     {
         $article = Article::whereSlug($slug)
             ->firstOrFail();
+        $oldTags = $article->tagList;
 
         $this->authorize('update', $article);
 
@@ -135,7 +136,7 @@ final class ArticleController extends Controller
 
         if (is_array($tags)) {
             if ($article->tagList !== $tags) {
-                $article->syncTags($tags);
+                $article->syncTags($tags, $oldTags);
             }
 
         }

--- a/server/app/Http/Controllers/Api/Articles/ArticleController.php
+++ b/server/app/Http/Controllers/Api/Articles/ArticleController.php
@@ -123,12 +123,21 @@ final class ArticleController extends Controller
      */
     public function update(UpdateArticleRequest $request, string $slug): ArticleResource
     {
+        $user = $request->user();
         $article = Article::whereSlug($slug)
             ->firstOrFail();
 
         $this->authorize('update', $article);
 
+        $attributes = $request->validated();
+        $attributes['author_id'] = $user->getKey();
+
+        $tags = Arr::pull($attributes, 'tagList');
         $article->update($request->validated());
+
+        if (is_array($tags)) {
+            $article->attachTags($tags);
+        }
 
         return new ArticleResource($article);
     }

--- a/server/app/Http/Controllers/Api/Articles/ArticleController.php
+++ b/server/app/Http/Controllers/Api/Articles/ArticleController.php
@@ -136,11 +136,7 @@ final class ArticleController extends Controller
         $article->update($request->validated());
 
         if (is_array($tags)) {
-            if (1 === count($tags) && empty($tags[0])) {
-                $article->attachTags([]);
-            } else {
-                $article->attachTags($tags);
-            }
+            $article->attachTags($tags);
         }
 
         return new ArticleResource($article);

--- a/server/app/Http/Requests/Api/UpdateArticleRequest.php
+++ b/server/app/Http/Requests/Api/UpdateArticleRequest.php
@@ -26,7 +26,7 @@ final class UpdateArticleRequest extends BaseArticleRequest
             'description' => ['required_without_all:title,body'],
             'body'        => ['required_without_all:title,description'],
             'tagList'     => 'sometimes|array',
-            'tagList.*'   => 'nullable|string|max:255',
+            'tagList.*'   => 'required|string|max:255',
             'image'       => "sometimes|nullable|string|url",
         ];
     }

--- a/server/app/Http/Requests/Api/UpdateArticleRequest.php
+++ b/server/app/Http/Requests/Api/UpdateArticleRequest.php
@@ -26,7 +26,7 @@ final class UpdateArticleRequest extends BaseArticleRequest
             'description' => ['required_without_all:title,body'],
             'body'        => ['required_without_all:title,description'],
             'tagList'     => 'sometimes|array',
-            'tagList.*'   => 'required|string|max:255',
+            'tagList.*'   => 'nullable|string|max:255',
             'image'       => "sometimes|nullable|string|url",
         ];
     }

--- a/server/app/Http/Requests/Api/UpdateArticleRequest.php
+++ b/server/app/Http/Requests/Api/UpdateArticleRequest.php
@@ -25,6 +25,8 @@ final class UpdateArticleRequest extends BaseArticleRequest
             // 'slug'        => ['required_with:title', 'alpha_dash', $unique],
             'description' => ['required_without_all:title,body'],
             'body'        => ['required_without_all:title,description'],
+            'tagList'     => 'sometimes|array',
+            'tagList.*'   => 'required|string|max:255',
             'image'       => "sometimes|nullable|string|url",
         ];
     }

--- a/server/app/Models/Article.php
+++ b/server/app/Models/Article.php
@@ -200,7 +200,7 @@ final class Article extends Model
      *
      * @param array<string> $tags
      */
-    public function syncTags(array $tags): void
+    public function syncTags(array $tags, array $oldTags = null): void
     {
         $tagIds = [];
 
@@ -213,11 +213,17 @@ final class Article extends Model
         }
         $this->tags()->sync($tagIds);
 
+        $properties = [
+            'tags' => $tags,
+        ];
+
+        if (null !== $oldTags) {
+            $properties['old_tags'] = $oldTags;
+        }
+
         activity('ArticleTags')
             ->performedOn($this)
-            ->withProperties(
-                ['tags' => $tags]
-            )
+            ->withProperties($properties)
             ->log('Tags anexadas ao artigo de id: ' . $this->id);
     }
 

--- a/server/app/Models/Article.php
+++ b/server/app/Models/Article.php
@@ -195,13 +195,16 @@ final class Article extends Model
      */
     public function attachTags(array $tags): void
     {
+        $tagIds = [];
+
         foreach ($tags as $tagName) {
             $tag = Tag::firstOrCreate([
                 'name' => $tagName,
             ]);
 
-            $this->tags()->syncWithoutDetaching($tag);
+            $tagIds[] = $tag->id;
         }
+        $this->tags()->sync($tagIds);
     }
 
     /**

--- a/server/app/Models/Article.php
+++ b/server/app/Models/Article.php
@@ -65,6 +65,13 @@ final class Article extends Model
         'image',
     ];
 
+    /**
+     * The attributes that should be appended to the model.
+     */
+    protected $appends = [
+        'tagList',
+    ];
+
     public function sluggable(): array
     {
 
@@ -245,5 +252,16 @@ final class Article extends Model
     public function favoredUsers()
     {
         return $this->belongsToMany(User::class, 'article_favorite');
+    }
+
+    /**
+     * Get the tag list attribute.
+     *
+     * @return array<string>
+     */
+    public function getTagListAttribute(): array
+    {
+        return $this->tags->pluck('name')->toArray();
+
     }
 }

--- a/server/app/Models/Article.php
+++ b/server/app/Models/Article.php
@@ -204,10 +204,6 @@ final class Article extends Model
     {
         $tagIds = [];
 
-        if ($this->tagList === $tags) {
-            return;
-        }
-
         foreach ($tags as $tagName) {
             $tag = Tag::firstOrCreate([
                 'name' => $tagName,

--- a/server/app/Models/Article.php
+++ b/server/app/Models/Article.php
@@ -212,6 +212,13 @@ final class Article extends Model
             $tagIds[] = $tag->id;
         }
         $this->tags()->sync($tagIds);
+
+        activity('ArticleTags')
+            ->performedOn($this)
+            ->withProperties(
+                ['tags' => $tags]
+            )
+            ->log('Tags anexadas ao artigo de id: ' . $this->id);
     }
 
     /**

--- a/server/app/Models/Article.php
+++ b/server/app/Models/Article.php
@@ -204,6 +204,10 @@ final class Article extends Model
     {
         $tagIds = [];
 
+        if ($this->tagList === $tags) {
+            return;
+        }
+
         foreach ($tags as $tagName) {
             $tag = Tag::firstOrCreate([
                 'name' => $tagName,

--- a/server/app/Models/Article.php
+++ b/server/app/Models/Article.php
@@ -200,7 +200,7 @@ final class Article extends Model
      *
      * @param array<string> $tags
      */
-    public function attachTags(array $tags): void
+    public function syncTags(array $tags): void
     {
         $tagIds = [];
 

--- a/server/tests/Feature/Api/Article/UpdateArticleTest.php
+++ b/server/tests/Feature/Api/Article/UpdateArticleTest.php
@@ -274,7 +274,7 @@ final class UpdateArticleTest extends TestCase
 
     public function testUpdateTagsIncludesNewTag(): void
     {
-        $this->article->attachTags($this->faker->words(3));
+        $this->article->syncTags($this->faker->words(3));
         $articleSlug = $this->article->slug;
 
         $articleTagsIncludedNewTag = [...$this->article->tagList, "new-tag"];
@@ -293,7 +293,7 @@ final class UpdateArticleTest extends TestCase
 
     public function testUpdateAllTags(): void
     {
-        $this->article->attachTags($this->faker->words(3));
+        $this->article->syncTags($this->faker->words(3));
 
         $articleSlug = $this->article->slug;
         $articleTags = $this->article->tagList;
@@ -313,7 +313,7 @@ final class UpdateArticleTest extends TestCase
     public function testUpdateTagsEmpty(): void
     {
 
-        $this->article->attachTags($this->faker->words(3));
+        $this->article->syncTags($this->faker->words(3));
 
         $articleSlug = $this->article->slug;
 

--- a/server/tests/Feature/Api/Article/UpdateArticleTest.php
+++ b/server/tests/Feature/Api/Article/UpdateArticleTest.php
@@ -320,4 +320,102 @@ final class UpdateArticleTest extends TestCase
         $this->assertNotEquals($manualSlugAttempt, $slug2);
     }
 
+    public function testUpdateTagsIncludesNewTag(): void
+    {
+        /** @var User $author */
+        $author = User::factory()->create();
+
+        $articleTags = $this->faker->words(3);
+
+        $articleTitle = $this->faker->sentence(4);
+
+        $response = $this->actingAs($author)->postJson("/api/articles", [
+            "article" => [
+                "title"       => $articleTitle,
+                "image"       => $this->faker->imageUrl(),
+                "description" => $this->faker->paragraph(),
+                "body"        => $this->faker->text(),
+                "tagList"     => $articleTags,
+            ],
+        ]);
+
+        $slug = $response->decodeResponseJson()['article']['slug'];
+
+        $articleTagsIncludedNewTag = [...$articleTags, "new-tag"];
+
+        $response2 = $this->actingAs($author)->putJson("/api/articles/{$slug}", [
+            "article" => [
+                "title"   => $articleTitle,
+                "tagList" => $articleTagsIncludedNewTag,
+            ],
+        ]);
+
+        $articleTagsUpdated = $response2->decodeResponseJson()['article']['tagList'];
+
+        $this->assertEquals($articleTagsIncludedNewTag, $articleTagsUpdated);
+    }
+
+    public function testUpdateAllTags(): void
+    {
+        /** @var User $author */
+        $author = User::factory()->create();
+
+        $articleTags = $this->faker->words(3);
+
+        $articleTitle = $this->faker->sentence(4);
+
+        $response = $this->actingAs($author)->postJson("/api/articles", [
+            "article" => [
+                "title"       => $articleTitle,
+                "image"       => $this->faker->imageUrl(),
+                "description" => $this->faker->paragraph(),
+                "body"        => $this->faker->text(),
+                "tagList"     => $articleTags,
+            ],
+        ]);
+
+        $slug = $response->decodeResponseJson()['article']['slug'];
+
+        $response2 = $this->actingAs($author)->putJson("/api/articles/{$slug}", [
+            "article" => [
+                "title"   => $articleTitle,
+                "tagList" => ["new-tag"],
+            ],
+        ]);
+
+        $articleTagsUpdated = $response2->decodeResponseJson()['article']['tagList'];
+
+        $this->assertNotEquals($articleTags, $articleTagsUpdated);
+    }
+
+    public function testUpdateTagsEmpty(): void
+    {
+        /** @var User $author */
+        $author = User::factory()->create();
+
+        $articleTitle = $this->faker->sentence(4);
+
+        $response = $this->actingAs($author)->postJson("/api/articles", [
+            "article" => [
+                "title"       => $articleTitle,
+                "image"       => $this->faker->imageUrl(),
+                "description" => $this->faker->paragraph(),
+                "body"        => $this->faker->text(),
+                "tagList"     => $this->faker->words(3),
+            ],
+        ]);
+
+        $slug = $response->decodeResponseJson()['article']['slug'];
+
+        $response2 = $this->actingAs($author)->putJson("/api/articles/{$slug}", [
+            "article" => [
+                "title"   => $articleTitle,
+                "tagList" => [],
+            ],
+        ]);
+
+        $articleTagsUpdated = $response2->decodeResponseJson()['article']['tagList'];
+
+        $this->assertEmpty($articleTagsUpdated);
+    }
 }


### PR DESCRIPTION
## Mudanças propostas

Ao editar as tags de um artigo anteriormente, ela não era modificada. Agora elas são editadas corretamente!
## Tipo de mudança

- [x] Correção de bug
- [ ] Nova feature
- [ ] Refactor / Otimização
- [ ] Atualização de documentação

## Checklist

- [x] Testei minhas mudanças
- [x] As mudanças não quebraram os testes existentes
- [x] As mudanças não afetam o fluxo de instalação descrito no README. Caso sim, atualizei o README.
- [x] Escrevi pelo menos 1 teste automatizado
- [ ] Foi adicionado uma nova dependência ao projeto

## Issues

Issue resolvida por esse PR: #94 

Issues relacionada a esse PR:

## Instruções de testes

- Inicie o projeto
- Faça login com google
- Crie um artigo com tags
- Edite as tags

## Evidências

https://github.com/user-attachments/assets/f8363a43-3908-42cf-b5e9-f7fc383a1715


